### PR TITLE
Upgrading to .NET 9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
 
   - uses: actions/setup-dotnet@v4
     with:
-      dotnet-version: '8.0.x'
+      dotnet-version: '9.0.x'
 
   - if: ${{ !inputs.build-from-source }}
     uses: actions/setup-node@v4


### PR DESCRIPTION
To fix validation issue with NuGet on .NET 8; see https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1698

Note: this will also install .NET 8 if building from source (which is what we want for the moment, I think)