### PR TITLE
fix: Update distribution names for Dafny 4.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        dafny: [3.8.1, 3.13.1, 4.0.0, 4.9.1, 4.11.0, nightly-2023-02-28-80a0e49, nightly-latest]
+        dafny: [3.8.1, 3.13.1, 4.0.0, 4.9.1, 4.11.0, nightly-2025-01-30-7db1e5f, nightly-latest]
         include:
           # Test building from source from a subset of versions
           - dafny: 4.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        dafny: [3.8.1, 3.13.1, 4.0.0, 4.9.1, nightly-2023-02-28-80a0e49, nightly-latest]
+        dafny: [3.8.1, 3.13.1, 4.0.0, 4.9.1, 4.11.0, nightly-2023-02-28-80a0e49, nightly-latest]
         include:
           # Test building from source from a subset of versions
           - dafny: 4.0.0

--- a/dist/index.js
+++ b/dist/index.js
@@ -6851,8 +6851,10 @@ function getDistribution(platform, version) {
   const post312 =
     version.includes("nightly") ||
     versionToNumeric(version) >= versionToNumeric("3.13");
+  // We still have nightlies from before 4.11 in use though,
+  // so we DO have to check against the date when the nightlies switched to use newer names.
   const post410 =
-    version.includes("nightly") ||
+    (version.includes("nightly") && version >= "nightly-2025-08-15") ||
     versionToNumeric(version) >= versionToNumeric("4.11");
   if (post410) {
     switch (platform) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6851,7 +6851,19 @@ function getDistribution(platform, version) {
   const post312 =
     version.includes("nightly") ||
     versionToNumeric(version) >= versionToNumeric("3.13");
-  if (post312) {
+  const post410 =
+    version.includes("nightly") ||
+    versionToNumeric(version) >= versionToNumeric("4.11");
+  if (post410) {
+    switch (platform) {
+      case "win32":
+        return "windows-2022";
+      case "darwin":
+        return "macos-13";
+      default:
+        return "ubuntu-22.04";
+    }
+  } else if (post312) {
     switch (platform) {
       case "win32":
         return "windows-2019";

--- a/index.js
+++ b/index.js
@@ -148,7 +148,19 @@ function getDistribution(platform, version) {
   const post312 =
     version.includes("nightly") ||
     versionToNumeric(version) >= versionToNumeric("3.13");
-  if (post312) {
+  const post410 =
+    version.includes("nightly") ||
+    versionToNumeric(version) >= versionToNumeric("4.11");
+  if (post410) {
+    switch (platform) {
+      case "win32":
+        return "windows-2022";
+      case "darwin":
+        return "macos-13";
+      default:
+        return "ubuntu-22.04";
+    }
+  } else if (post312) {
     switch (platform) {
       case "win32":
         return "windows-2019";

--- a/index.js
+++ b/index.js
@@ -148,8 +148,10 @@ function getDistribution(platform, version) {
   const post312 =
     version.includes("nightly") ||
     versionToNumeric(version) >= versionToNumeric("3.13");
+  // We still have nightlies from before 4.11 in use though,
+  // so we DO have to check against the date when the nightlies switched to use newer names.
   const post410 =
-    version.includes("nightly") ||
+    (version.includes("nightly") && version >= "nightly-2025-08-15") ||
     versionToNumeric(version) >= versionToNumeric("4.11");
   if (post410) {
     switch (platform) {


### PR DESCRIPTION
Dafny 4.11 started to use newer GitHub Actions runner image names, so the logic to determine the distribution string here needs to be updated.

Also updated CI to test with a newer nightly build, since the old one has been deleted. I used the same one as https://github.com/aws/aws-cryptographic-material-providers-library/blob/main/project.properties#L10C18-L10C44 since that's the main one we're aware is still used.